### PR TITLE
Add tags to cards

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -570,6 +570,19 @@
   
       dragEnd(event) {
         this.set("dragging", false);
+      },
+
+      @computed('tags')
+      showTags(tags) {
+        return settings.show_tags && tags.length;
+      },
+
+      @computed("topic.tags", "definition.params.tags")
+      tags(topicTags, definitionTag) {
+        console.log(topicTags, definitionTag);
+        return topicTags
+          .filter(t => t != definitionTag)
+          .map(t => renderTag(t));
       }
     })
   );
@@ -654,7 +667,7 @@
   <div class="topics">
     {{#conditional-loading-spinner condition=loading}}
         {{#each list.topics as |topic|}}
-          {{discourse-kanban-card topic=topic setDragData=(action "setDragData")}}
+          {{discourse-kanban-card topic=topic setDragData=(action "setDragData") definition=definition}}
         {{else}}
           <div class="no_topics">
             {{theme-i18n "no_topics"}}
@@ -675,6 +688,15 @@
       {{format-date topic.bumpedAt format="tiny" noTitle="true"}}
     </div>
 
+    {{#if showTags}}
+      <div class="card-row">
+        <div class="tags">
+          {{#each tags as |tag|}}
+            {{{tag}}}
+          {{/each}}
+        </div>
+      </div>
+    {{/if}}
     
     <div class="card-row">
       <div class="posters">
@@ -717,5 +739,3 @@
   </div>
     
 </script>
-
-

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -579,7 +579,6 @@
 
       @computed("topic.tags", "definition.params.tags")
       tags(topicTags, definitionTag) {
-        console.log(topicTags, definitionTag);
         return topicTags
           .filter(t => t != definitionTag)
           .map(t => renderTag(t));

--- a/settings.yml
+++ b/settings.yml
@@ -15,7 +15,8 @@ require_confirmation:
 extra_icons:
   default: "user-minus"
   description:
-    en: Extra icons to load for the theme component. There is no need to change this setting.show_tags:
+    en: Extra icons to load for the theme component. There is no need to change this setting.
+show_tags:
   default: false
   description:
     en: Show tags on topic cards.

--- a/settings.yml
+++ b/settings.yml
@@ -15,4 +15,7 @@ require_confirmation:
 extra_icons:
   default: "user-minus"
   description:
-    en: Extra icons to load for the theme component. There is no need to change this setting.
+    en: Extra icons to load for the theme component. There is no need to change this setting.show_tags:
+  default: false
+  description:
+    en: Show tags on topic cards.


### PR DESCRIPTION
Adds a topic's tags to its kanban card, filtering out any active definition tag for the list the card is in. Includes a setting to toggle the behaviour.