### PR TITLE
Add plugin outlet

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -689,6 +689,8 @@
         </a>
       {{/if}}
     </div>
+    
+    {{plugin-outlet name="kanban-card-bottom" args=(hash topic=topic)}}
   </a>
 </script>
 


### PR DESCRIPTION
Adds a single plugin outlet to the bottom of the card. I'm thinking of using this for a few different plugins, particularly events.