### PR TITLE
Move draggable logic to a single element

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -112,6 +112,7 @@
 		.topic-card {
 			display: block;
 			color: $primary-medium;
+			cursor: pointer;
 			&.topic-unseen{
 				color: $primary;
 			}

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -561,15 +561,22 @@
   Discourse.register(
     "component:discourse-kanban-card",
     Ember.Component.extend({
-      draggable: "true",
-  
+      classNameBindings: [':topic-card', 'dragging', 'topic.unseen:topic-unseen'],
+      attributeBindings: ['draggable'],
+      draggable: true,
+
       dragStart(event) {
-        this.setDragData({ topic: this.topic });
         this.set("dragging", true);
+        this.setDragData({ topic: this.topic });
+        event.dataTransfer.setData('topic', this.topic);
       },
-  
+
       dragEnd(event) {
         this.set("dragging", false);
+      },
+
+      click(event) {
+        DiscourseURL.routeTo(this.topic.lastUnreadUrl);
       }
     })
   );
@@ -668,28 +675,26 @@
 
 
 <script type='text/x-handlebars' data-template-name='components/discourse-kanban-card'>
-  <a href={{topic.lastUnreadUrl}} draggable="true" class="topic-card {{if topic.unseen 'topic-unseen'}} {{if dragging 'dragging'}}">
-    <div class="card-row">
-      {{topic-status topic=topic}}
-      <span class="topic-title">{{topic.title}}</span>
-      {{format-date topic.bumpedAt format="tiny" noTitle="true"}}
+  <div class="card-row">
+    {{topic-status topic=topic}}
+    <span class="topic-title">{{topic.title}}</span>
+    {{format-date topic.bumpedAt format="tiny" noTitle="true"}}
+  </div>
+
+  
+  <div class="card-row">
+    <div class="posters">
+      {{#each topic.posters as |poster|}}
+        <a href="{{poster.user.path}}" data-user-card="{{poster.user.username}}" class="{{poster.extraClasses}}">{{avatar poster avatarTemplatePath="user.avatar_template" usernamePath="user.username" namePath="user.name" imageSize="tiny"}}</a>
+      {{/each}}
     </div>
 
-    
-    <div class="card-row">
-      <div class="posters">
-        {{#each topic.posters as |poster|}}
-          <a href="{{poster.user.path}}" data-user-card="{{poster.user.username}}" class="{{poster.extraClasses}}">{{avatar poster avatarTemplatePath="user.avatar_template" usernamePath="user.username" namePath="user.name" imageSize="tiny"}}</a>
-        {{/each}}
-      </div>
-
-      {{#if topic.assigned_to_user.username}}
-        <a class='assigned-to' href={{topic.assignedToUserPath}}>
-          {{d-icon 'user-plus'}}{{topic.assigned_to_user.username}}
-        </a>
-      {{/if}}
-    </div>
-  </a>
+    {{#if topic.assigned_to_user.username}}
+      <a class='assigned-to' href={{topic.assignedToUserPath}}>
+        {{d-icon 'user-plus'}}{{topic.assigned_to_user.username}}
+      </a>
+    {{/if}}
+  </div>
 </script>
 
 


### PR DESCRIPTION
The theme component currently has two "draggable" elements (.card-component and it's anchor element). This consolidates the logic into the component itself.

This has the benefit of giving us greater control over the route to the topic, i.e. using the click event instead of the anchor element's href. In doing so, it prevents a bug I've been experiencing: routing to the topic when a card is dropped.