### PR TITLE
Split and spread categories params

### DIFF
--- a/javascripts/discourse-kanban/services/kanban-helper.js.es6
+++ b/javascripts/discourse-kanban/services/kanban-helper.js.es6
@@ -101,7 +101,7 @@ export default Ember.Service.extend({
           if (param) {
             var categories = param
               .split(",")
-              .map(c => Discourse.Category.findBySlug(c));
+              .map(c => Discourse.Category.findBySlug(...c.split('/')));
             categories.filter(c => c !== undefined);
 
             lists.push(


### PR DESCRIPTION
Allows you to add sub-categories as params to a board in ``categories`` mode by splittin and spreadin.

Example usage:

```
parent:categories:child1/parent,child2/parent
```

Which would result in two columns for each child in the parent category.