### PR TITLE
Add default_view setting for categories

### DIFF
--- a/javascripts/discourse-kanban/connectors/extra-nav-item/kanban-connector.js.es6
+++ b/javascripts/discourse-kanban/connectors/extra-nav-item/kanban-connector.js.es6
@@ -1,10 +1,7 @@
+import { displayConnector } from '../../lib/kanban-utilities';
+
 export default {
     shouldRender(args, component) {
-        if (settings.display_categories === "") return true;
-    
-        const displayCategories = settings.display_categories.split("|");
-        const lookup = component.get("category.slug") || "@";
-        console.log(lookup, displayCategories);
-        return displayCategories.includes(lookup);
+        return displayConnector(component.get('category.slug'));
     }
 }

--- a/javascripts/discourse-kanban/initializers/initialize-discourse-kanban.js.es6
+++ b/javascripts/discourse-kanban/initializers/initialize-discourse-kanban.js.es6
@@ -1,5 +1,6 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import {default as computed, on, observes} from "ember-addons/ember-computed-decorators";
+import { displayConnector, boardDefaultView, isDefaultView } from '../lib/kanban-utilities'; 
 
 export default {
   name: "my-initializer",
@@ -32,6 +33,29 @@ export default {
             }
             return this._super(contentFilterMode, filterMode);
             }
+        });
+        
+        const routeToBoard = (transition, categorySlug) => {
+          return isDefaultView(transition) &&
+            displayConnector(categorySlug) &&
+            boardDefaultView(categorySlug);
+        }
+
+        [
+         'category',
+         'parentCategory',
+         'categoryNone',
+         'categoryWithID'
+        ].forEach(function(route){
+          api.modifyClass(`route:discovery.${route}`, {
+            afterModel(model, transition) {
+              if (routeToBoard(transition, model.category.slug)) {
+                return this.replaceWith(`${model.category.get('url')}/l/latest?board=default`);
+              } else {
+                return this._super(...arguments);
+              }
+            }
+          });
         });
     });
   }

--- a/javascripts/discourse-kanban/lib/kanban-utilities.js.es6
+++ b/javascripts/discourse-kanban/lib/kanban-utilities.js.es6
@@ -1,0 +1,22 @@
+const categorySetting = (type, slug, allowTopRoutes = true) => {
+  if (!slug && !allowTopRoutes) return false;
+  const categories = settings[type].split("|");
+  const lookup = slug || "@";
+  return categories.includes(lookup);
+}
+
+const displayConnector = (categorySlug) => {
+  return settings.display_categories === "" ||
+    categorySetting('display_categories', categorySlug);
+}
+
+const boardDefaultView = (categorySlug) => {
+  return categorySetting('default_view', categorySlug, false);
+}
+
+const isDefaultView = (transition) => {
+  let path = transition.intent.url || window.location.pathname;
+  return path.indexOf('/l/') === -1;
+}
+
+export { displayConnector, boardDefaultView, isDefaultView }

--- a/settings.yml
+++ b/settings.yml
@@ -8,6 +8,11 @@ default_modes:
   default: ""
   description:
     en: "Override the default board mode for each category. Use the syntax `category:mode:params`. For example, `support:assigned:david,sam,joffrey`. Use @ to denote the top level view. Use @untagged to display an untagged column."
+default_view:
+  type: list
+  default: ""
+  description:
+    en: A list of categories where the "Board" is the default view. Does not yet support the top level default view.
 require_confirmation:
   default: true
   description:


### PR DESCRIPTION
Allows you to set the board route as the default view of a category. Does not yet support adding board as the top level default view, but allows for that extension in the future.