### PR TITLE
FIX: Ensure kanban is activated for all types of link

### DIFF
--- a/javascripts/discourse-kanban/lib/kanban-utilities.js.es6
+++ b/javascripts/discourse-kanban/lib/kanban-utilities.js.es6
@@ -19,8 +19,7 @@ const boardDefaultView = (categorySlug) => {
 };
 
 const isDefaultView = (transition) => {
-  let path = transition.intent.url || window.location.pathname;
-  return path.indexOf("/l/") === -1;
+  return transition.to.name === "discovery.category";
 };
 
 export { displayConnector, boardDefaultView, isDefaultView };


### PR DESCRIPTION
Previously it wouldn't trigger if the transition was triggered by an ember `{{link-to`. Now it uses the ember router