### PR TITLE
FIX: Category slug filter isn't working; UX: Add Chinese I18n support

### DIFF
--- a/javascripts/discourse-kanban/connectors/extra-nav-item/kanban-connector.js
+++ b/javascripts/discourse-kanban/connectors/extra-nav-item/kanban-connector.js
@@ -1,7 +1,7 @@
 import { displayConnector } from "../../lib/kanban-utilities";
 
 export default {
-  shouldRender(args, component) {
-    return displayConnector(component.get("category.slug"));
+  shouldRender(args) {
+    return displayConnector(args?.category?.slug || args?.category?.name);
   },
 };

--- a/locales/zh_CN.yml
+++ b/locales/zh_CN.yml
@@ -1,0 +1,15 @@
+zh_CN:
+  no_topics: 暂无话题
+  confirm_change_tags: 确认要对话题 '%{title}' 把 '#%{remove}' 替换为 '#%{add}' 吗?
+  confirm_close: 确认要关闭话题 '%{title}' 吗?
+  confirm_open: 确认要重新打开话题 '%{title}' 吗?
+  confirm_change_category: 确认要移动话题 '%{title}' 吗?
+  menu_label: "看板"
+  modal:
+    title: "看板选项"
+    tags_placeholder: 要展示的标签...
+    categories_placeholder: 要展示的类别...
+    usernames_placeholder: 要展示的用户...
+    apply: 应用
+  theme_metadata:
+    description: 该主题组件允许你在一个看板中列出和组织话题。屏幕上方将会出现新的按钮“看板”。

--- a/settings.yml
+++ b/settings.yml
@@ -3,29 +3,36 @@ display_categories:
   default: ""
   description:
     en: A list of categories where the "Board" button should appear. If left blank, it will be shown everywhere. Use @ to denote the top level view.
+    zh_CN: “看板”按钮会出现的类别列表。填写类别缩略名，而不是类别名。如果留空，它将全局出现。使用@作为顶级视图的代号。
 default_modes:
   type: list
   default: ""
   description:
     en: "Override the default board mode for each category. Use the syntax `category:mode:params`. For example, `support:assigned:david,sam,joffrey`. Use @ to denote the top level view. Use @untagged to display an untagged column."
+    zh_CN: "对这些类别，修改“看板”按钮的默认呈现方式。格式为：`类别:模式:参数`，特别地，类别参数需要用数字指代，例如：`support:assigned:david,sam,joffrey`。使用@作为顶级视图的代号。使用@untagged作为无标签列的代号。"
 default_view:
   type: list
   default: ""
   description:
     en: A list of categories where the "Board" is the default view. Does not yet support the top level default view.
+    zh_CN: "看板作为默认视图的类别列表。不支持顶级视图。"
 require_confirmation:
   default: true
   description:
     en: Display a confirmation modal before making changes to a topic's tags/category?
+    zh_CN: "在对话题的标签/类别做出更改时，显示确认对话框"
 show_tags:
   default: false
   description:
     en: Show tags on topic cards?
+    zh_CN: "在看板卡片上显示话题的标签。"
 num_columns:
   default: 3
   description:
     en: Number of columns to display on screen. More are available by scrolling
+    zh_CN: "屏幕上能容纳多少列看板。（更多的列可以通过滑动看到）。"
 extra_icons:
   default: "user-minus"
   description:
     en: Extra icons to load for the theme component. There is no need to change this setting.
+    zh_CN: "主题组件加载的额外图标。没有必要修改这个设置。"


### PR DESCRIPTION
These changes address the bug where the Board nav button did not appear when categories are added to the display_categories setting.

[![Discourse Theme](https://github.com/Lhcfl/discourse-kanban-theme/actions/workflows/discourse-theme.yml/badge.svg)](https://github.com/Lhcfl/discourse-kanban-theme/actions/workflows/discourse-theme.yml)