### PR TITLE
DEV: Better calculations of list height

### DIFF
--- a/javascripts/discourse/services/kanban-manager.js
+++ b/javascripts/discourse/services/kanban-manager.js
@@ -121,9 +121,16 @@ export default class KanbanManager extends Service {
     const mainOutlet = document.querySelector("#main-outlet");
     const mainOutletHeight = mainOutlet.getBoundingClientRect().height;
     const mainOutletPadding = 40;
-    const listControlsHeight = mainOutlet
-      .querySelector(".list-controls")
-      .getBoundingClientRect().height;
+
+    // Get all previous siblings of the list container and add their heights
+    let currentElement =
+      mainOutlet.querySelector(".list-container").previousElementSibling;
+    let previousSiblingsHeight = 0;
+    while (currentElement !== null) {
+      previousSiblingsHeight += currentElement.getBoundingClientRect().height;
+      currentElement = currentElement.previousElementSibling;
+    }
+
     const listTitleHeight = mainOutlet
       .querySelector(".list-title")
       .getBoundingClientRect().height;
@@ -134,7 +141,7 @@ export default class KanbanManager extends Service {
     } else {
       height =
         mainOutletHeight -
-        listControlsHeight -
+        previousSiblingsHeight -
         listTitleHeight -
         mainOutletPadding;
     }


### PR DESCRIPTION
With endless customization options being possible in a given forum, we can't manually calculate the height of the list... To get around this we can look at any previous (element) siblings of the list and their total combined height to calculate the list height and any offset needed.