### PR TITLE
UX: Enable detailed card view by default

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -22,7 +22,7 @@ show_tags:
   description:
     en: Show tags on topic cards?
 card_style:
-  default: simple
+  default: detailed
   type: enum
   choices:
     - simple


### PR DESCRIPTION
This is closer to the old default implementation, so provides a smoother upgrade path