### PR TITLE
UX: Tweak JS height calculation logic

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,14 +1,23 @@
 html:has(body.kanban-active) {
   overscroll-behavior: none;
+
+  #list-area {
+    margin-bottom: 0;
+  }
 }
 
 .discourse-kanban {
   position: relative;
-  height: 100%;
-  --d-sidebar-gap: 2em;
-  @media screen and (max-width: 1000px) {
-    --d-sidebar-gap: 1em;
-  }
+
+  // The amount of space available without causing the page to scroll:
+  --desired-height: calc(100vh - var(--kanban-offset-top));
+
+  // Use the desired height, unless it is smaller than 500px
+  height: max(var(--desired-height), 500px);
+
+  padding-bottom: 10px;
+  overflow-x: scroll;
+  box-sizing: border-box;
 
   &.kanban-fullscreen {
     position: fixed;
@@ -19,10 +28,10 @@ html:has(body.kanban-active) {
     z-index: z("fullscreen");
     background-color: var(--secondary);
     width: 100%;
+    height: 100%;
     padding: 0;
     margin: 0;
     display: flex;
-    justify-content: center;
 
     .discourse-kanban-container {
       height: auto;
@@ -59,12 +68,13 @@ html:has(body.kanban-active) {
 .discourse-kanban-container {
   height: 100%;
   display: flex;
-  overflow-y: scroll;
   gap: 0 10px;
 
   .discourse-kanban-list {
     background: var(--primary-100);
     border: 1px solid var(--primary-low);
+    display: flex;
+    flex-direction: column;
 
     &.kanban-empty-state {
       padding: 2em 1em;
@@ -91,6 +101,7 @@ html:has(body.kanban-active) {
     .topics {
       overflow-y: scroll;
       padding: 0 8px;
+      height: 100%;
     }
 
     .topic-card {
@@ -203,21 +214,6 @@ html:has(body.kanban-active) {
   .select-kit,
   div.ac-wrap {
     width: 100%;
-  }
-}
-
-body.kanban-active {
-  #main-outlet {
-    height: calc(100dvh - var(--header-offset) - 2.5em);
-  }
-
-  .list-container .row:nth-child(2),
-  .full-width {
-    height: 100%;
-  }
-
-  #list-area {
-    height: 100%;
   }
 }
 

--- a/javascripts/discourse/components/kanban/list.gjs
+++ b/javascripts/discourse/components/kanban/list.gjs
@@ -2,10 +2,8 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { inject as service } from "@ember/service";
 import { modifier } from "ember-modifier";
-import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import concatClass from "discourse/helpers/concat-class";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import Topic from "discourse/models/topic";
@@ -13,15 +11,6 @@ import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 import I18n from "I18n";
 import DiscourseKanbanCard from "./card";
-
-export const onWindowReize = modifier((element, [callback]) => {
-  const wrappedCallback = () => callback(element);
-  window.addEventListener("resize", wrappedCallback);
-
-  return () => {
-    window.removeEventListener("resize", wrappedCallback);
-  };
-});
 
 function removedElements(before, after) {
   if (!before) {
@@ -296,12 +285,10 @@ export default class KanbanList extends Component {
         {{this.renderedTitle}}
       </div>
 
-      <ConditionalLoadingSpinner @condition={{this.loading}}>
-        <div
-          class="topics"
-          {{onWindowReize this.kanbanManager.calcListsHeights}}
-          {{didInsert this.kanbanManager.calcListsHeights}}
-        >
+      {{#if this.loading}}
+        <div class="spinner"></div>
+      {{else}}
+        <div class="topics">
           {{#each this.list.topics as |topic|}}
             <DiscourseKanbanCard
               @topic={{topic}}
@@ -316,7 +303,7 @@ export default class KanbanList extends Component {
 
           <div class="list-bottom" {{onIntersection this.loadMore}}></div>
         </div>
-      </ConditionalLoadingSpinner>
+      {{/if}}
     </div>
   </template>
 }

--- a/javascripts/discourse/services/kanban-manager.js
+++ b/javascripts/discourse/services/kanban-manager.js
@@ -1,5 +1,5 @@
 import { tracked } from "@glimmer/tracking";
-import { action, get } from "@ember/object";
+import { get } from "@ember/object";
 import Service, { inject as service } from "@ember/service";
 import Category from "discourse/models/category";
 import buildAssignedLists from "../lib/kanban-list-builders/assigned";
@@ -114,42 +114,6 @@ export default class KanbanManager extends Service {
 
   get mode() {
     return this.resolvedDescriptorParts[0];
-  }
-
-  @action
-  calcListsHeights() {
-    const mainOutlet = document.querySelector("#main-outlet");
-    const mainOutletHeight = mainOutlet.getBoundingClientRect().height;
-    const mainOutletPadding = 40;
-
-    // Get all previous siblings of the list container and add their heights
-    let currentElement =
-      mainOutlet.querySelector(".list-container").previousElementSibling;
-    let previousSiblingsHeight = 0;
-    while (currentElement !== null) {
-      previousSiblingsHeight += currentElement.getBoundingClientRect().height;
-      currentElement = currentElement.previousElementSibling;
-    }
-
-    const listTitleHeight = mainOutlet
-      .querySelector(".list-title")
-      .getBoundingClientRect().height;
-    let height;
-    if (this.fullscreen) {
-      // the 10px is for the padding on the top of the list
-      height = mainOutletHeight + 10;
-    } else {
-      height =
-        mainOutletHeight -
-        previousSiblingsHeight -
-        listTitleHeight -
-        mainOutletPadding;
-    }
-
-    const lists = document.querySelectorAll(".discourse-kanban-list .topics");
-    lists.forEach((element) => {
-      element.style.height = `${height}px`;
-    });
   }
 
   findDefinition() {


### PR DESCRIPTION
- Moves the height calculation to the wrapper element so we don't need to re-calculate for every list
- Instead of enumerating the sibling elements, calculate an `--kanban-offset` value for the top of the wrapper, and then use css viewport height to work out how much space is remaining
- Set a minimum of 500px so that the kanban is still usable on sites with very large headers/footers.