### PR TITLE
FIX: Restore behaviour for `displayCategory` setting

### DIFF
--- a/javascripts/discourse/components/kanban/nav.gjs
+++ b/javascripts/discourse/components/kanban/nav.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import concatClass from "discourse/helpers/concat-class";
 import i18n from "discourse-common/helpers/i18n";
+import { displayConnector } from "../../lib/kanban-utilities";
 
 export default class KanbanNav extends Component {
   @service kanbanManager;
@@ -19,13 +20,15 @@ export default class KanbanNav extends Component {
   }
 
   <template>
-    <li>
-      <a
-        href={{this.href}}
-        class={{concatClass "kanban-nav" (if this.active "active")}}
-      >
-        {{i18n (themePrefix "menu_label")}}
-      </a>
-    </li>
+    {{#if (displayConnector this.kanbanManager.discoveryCategory.slug)}}
+      <li>
+        <a
+          href={{this.href}}
+          class={{concatClass "kanban-nav" (if this.active "active")}}
+        >
+          {{i18n (themePrefix "menu_label")}}
+        </a>
+      </li>
+    {{/if}}
   </template>
 }

--- a/javascripts/discourse/services/kanban-manager.js
+++ b/javascripts/discourse/services/kanban-manager.js
@@ -8,6 +8,7 @@ import buildTagLists from "../lib/kanban-list-builders/tags";
 
 export default class KanbanManager extends Service {
   @service router;
+  @service discovery;
 
   @tracked fullscreen;
 
@@ -47,15 +48,15 @@ export default class KanbanManager extends Service {
   }
 
   get discoveryTopTags() {
-    return this.discoveryRouteAttribute("list.topic_list.top_tags");
+    return this.discovery.currentTopicList?.get("topic_list.top_tags");
   }
 
   get discoveryCategory() {
-    return this.discoveryRouteAttribute("category");
+    return this.discovery.category;
   }
 
   get discoveryTag() {
-    return this.discoveryRouteAttribute("tag");
+    return this.discovery.tag;
   }
 
   get active() {
@@ -63,7 +64,10 @@ export default class KanbanManager extends Service {
   }
 
   get currentDescriptor() {
-    return this.discoveryParams && get(this.discoveryParams, "board");
+    return (
+      this.discovery.onDiscoveryRoute &&
+      this.router.currentRoute?.queryParams?.board
+    );
   }
 
   get listDefinitions() {


### PR DESCRIPTION
The ability to restrict the menu item to certain categories was lost in the recent refactoring. This restores it, and updates things to use core's new 'discovery' service.