### PR TITLE
DEV: Refresh auto groups in tests to make them pass

### DIFF
--- a/spec/system/kanban_functionality_spec.rb
+++ b/spec/system/kanban_functionality_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe "Testing A Theme or Theme Component", system: true do
   fab!(:modern_js_backlog) { tagged_topic(modern_js, backlog) }
   fab!(:chat_backlog) { tagged_topic(chat, backlog) }
 
-  fab!(:user) { Fabricate(:admin) }
+  fab!(:user) { Fabricate(:admin, refresh_auto_groups: true) }
 
   let!(:theme) { upload_theme_component }
 
-  before {     sign_in user }
+  before { sign_in user }
 
   it "should function without tag / category filters" do
     visit "/"


### PR DESCRIPTION
### What is this change?

We changed our access settings to be based on group membership rather than TL column. This requires some tests to refresh the group memberships to have the tests keep passing.