### PR TITLE
DEV: Resolve unused translations

### DIFF
--- a/javascripts/discourse/components/kanban/modal/options.gjs
+++ b/javascripts/discourse/components/kanban/modal/options.gjs
@@ -96,16 +96,18 @@ export default class KanbanOptionsController extends Component {
             <TagChooser
               @tags={{this.tags}}
               @allowCreate={{false}}
-              @filterPlaceholder={{i18n (themePrefix "modal.tags_placeholder")}}
               @everyTag={{true}}
+              @options={{hash
+                filterPlaceholder=(themePrefix "modal.tags_placeholder")
+              }}
               class="kanban-tag-chooser"
             />
           {{else if this.isCategories}}
             <MultiSelect
               @content={{this.site.categories}}
               @value={{this.categories}}
-              @filterPlaceholder={{i18n
-                (themePrefix "modal.categories_placeholder")
+              @options={{hash
+                filterPlaceholder=(themePrefix "modal.categories_placeholder")
               }}
             />
           {{else if this.isAssigned}}

--- a/javascripts/discourse/components/kanban/wrapper.gjs
+++ b/javascripts/discourse/components/kanban/wrapper.gjs
@@ -68,7 +68,7 @@ export default class Kanban extends Component {
               class="fullscreen-close"
               @icon="times"
               @action={{this.exitFullscreen}}
-              title={{themePrefix "fullscreen"}}
+              @title={{themePrefix "fullscreen"}}
             />
           </div>
         {{/if}}


### PR DESCRIPTION
Moin reported this behavior to me while translating the component.

This PR fixes the placeholders for the tags and categories chooser.

Before:
![iLNJYeVv9E](https://github.com/discourse/discourse-kanban-theme/assets/360640/5efb20ff-0460-4681-adc7-a880cf134d19)

After:
![EbxAqffgEj](https://github.com/discourse/discourse-kanban-theme/assets/360640/21c99d3a-3f9f-495a-aed2-91a25ede8558)

---

EDIT: Added another commit to resolve the fullscreen title not being translated.

![DHyetgWr3d](https://github.com/discourse/discourse-kanban-theme/assets/360640/6faf2445-95dc-4aaa-8acb-0e3122d6ee66)
