### PR TITLE
FEATURE: Allows display topic thumbnails in kanban cards

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -138,6 +138,10 @@ html:has(body.kanban-active) {
           }
         }
 
+        &__thumbnail-row {
+          margin-top: 5px;
+        }
+
         .last-post-by,
         .topic-title {
           flex-grow: 1;
@@ -160,6 +164,11 @@ html:has(body.kanban-active) {
             font-size: $font-down-2;
             color: var(--primary-medium);
           }
+        }
+
+        .thumbnail {
+          overflow: hidden;
+          width: 100%;
         }
 
         .last-post-by {

--- a/javascripts/discourse/components/kanban/card.gjs
+++ b/javascripts/discourse/components/kanban/card.gjs
@@ -186,7 +186,7 @@ export default class KanbanCard extends Component {
 
       {{#if this.showImage}}
         <div class="card-row card-row__thumbnail-row">
-          <img class="thumbnail" src="{{this.imageUrl}}" />
+          <img class="thumbnail" src={{this.imageUrl}} />
         </div>
       {{/if}}
 

--- a/javascripts/discourse/components/kanban/card.gjs
+++ b/javascripts/discourse/components/kanban/card.gjs
@@ -51,6 +51,14 @@ export default class KanbanCard extends Component {
       .map((t) => renderTag(t));
   }
 
+  get showImage() {
+    return settings.show_topic_thumbnail && this.imageUrl;
+  }
+
+  get imageUrl() {
+    return this.args.topic.image_url;
+  }
+
   get showCategory() {
     const definitionCategory = this.args.definition.params.category;
     const discoveryCategory = this.kanbanManager.discoveryCategory;
@@ -173,6 +181,12 @@ export default class KanbanCard extends Component {
               {{/each-in}}
             {{/if}}
           </div>
+        </div>
+      {{/if}}
+
+      {{#if this.showImage}}
+        <div class="card-row card-row__thumbnail-row">
+          <img class="thumbnail" src="{{this.imageUrl}}" />
         </div>
       {{/if}}
 

--- a/settings.yml
+++ b/settings.yml
@@ -27,3 +27,7 @@ card_style:
   choices:
     - simple
     - detailed
+show_topic_thumbnail:
+  default: false
+  description:
+    en: Display the topic thumbnail at the bottom of the card


### PR DESCRIPTION
This commit adds an optional, non-default setting to allow showing topic thumbnails on board cards.

This submission does not affect the card style when the switch is not turned on.

After:
![image](https://github.com/discourse/discourse-kanban-theme/assets/41134017/986bb535-3528-4092-a559-491dc75a23dd)

![image](https://github.com/discourse/discourse-kanban-theme/assets/41134017/ce071391-5987-4938-92c0-8a1be2574a0f)
