### PR TITLE
FEATURE: Activity indicators for cards

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -119,6 +119,14 @@ html:has(body.kanban-active) {
         background-color: var(--tertiary-low);
       }
 
+      &.card-no-recent-activity {
+        background-color: var(--highlight-bg);
+      }
+
+      &.card-stale {
+        background-color: var(--quaternary-low);
+      }
+
       .card-row {
         display: flex;
         align-items: baseline;

--- a/common/common.scss
+++ b/common/common.scss
@@ -120,11 +120,11 @@ html:has(body.kanban-active) {
       }
 
       &.card-no-recent-activity {
-        background-color: var(--highlight-bg);
+        border-left: 5px solid var(--danger-low);
       }
 
       &.card-stale {
-        background-color: var(--quaternary-low);
+        border-left: 5px solid var(--danger-medium);
       }
 
       .card-row {

--- a/javascripts/discourse/components/kanban/card.gjs
+++ b/javascripts/discourse/components/kanban/card.gjs
@@ -87,6 +87,7 @@ export default class KanbanCard extends Component {
     if (bumpedAt < moment().add(-7, "days")) {
       return "card-no-recent-activity";
     }
+
     return "";
   }
 

--- a/javascripts/discourse/components/kanban/card.gjs
+++ b/javascripts/discourse/components/kanban/card.gjs
@@ -74,12 +74,29 @@ export default class KanbanCard extends Component {
       poster.extras?.includes("latest")
     );
   }
+
+  get cardActivityCssClass() {
+    if (!settings.show_activity_indicators) {
+      return "";
+    }
+
+    const bumpedAt = moment(this.args.topic.bumpedAt);
+    if (bumpedAt < moment().add(-20, "days")) {
+      return "card-stale";
+    }
+    if (bumpedAt < moment().add(-7, "days")) {
+      return "card-no-recent-activity";
+    }
+    return "";
+  }
+
   <template>
     <a
       class={{concatClass
         "topic-card"
         (if this.topic.unseen "topic-unseen")
         (if this.dragging "dragging")
+        this.cardActivityCssClass
       }}
       draggable="true"
       href={{@topic.lastUnreadUrl}}

--- a/settings.yml
+++ b/settings.yml
@@ -34,4 +34,4 @@ show_topic_thumbnail:
 show_activity_indicators:
   default: false
   description:
-    en: Display an indicator of a card's activity. If the topic has been bumped more than 7 days ago or more than 20 days ago a different CSS class will be applied.
+    en: Display an indicator of a card's activity. If the topic has been bumped more than 7 days ago or more than 20 days ago a different style will be applied.

--- a/settings.yml
+++ b/settings.yml
@@ -31,3 +31,7 @@ show_topic_thumbnail:
   default: false
   description:
     en: Display the topic thumbnail at the bottom of the card
+show_activity_indicators:
+  default: false
+  description:
+    en: Display an indicator of a card's activity. If the topic has been bumped more than 7 days agoor more than 20 days ago a different CSS class will be applied.

--- a/settings.yml
+++ b/settings.yml
@@ -34,4 +34,4 @@ show_topic_thumbnail:
 show_activity_indicators:
   default: false
   description:
-    en: Display an indicator of a card's activity. If the topic has been bumped more than 7 days agoor more than 20 days ago a different CSS class will be applied.
+    en: Display an indicator of a card's activity. If the topic has been bumped more than 7 days ago or more than 20 days ago a different CSS class will be applied.


### PR DESCRIPTION
This commit adds a show_activity_indicators setting,
if set to true then a CSS class will be applied to
cards where the bumped_at date is:

* > 7 days
* > 20 days

This will style cards which will make it easier to
scan the board and see which cards may be languishing.

![image](https://github.com/user-attachments/assets/0a0f7348-e6ed-4a82-bef5-3976027d3830)

