### PR TITLE
FIX: Use box-shadow for activity indicators

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -120,11 +120,15 @@ html:has(body.kanban-active) {
       }
 
       &.card-no-recent-activity {
-        border-left: 5px solid var(--danger-low);
+        box-shadow: inset 5px 0px 0 0px var(--danger-low);
+        border-left: 0px;
+        padding-left: 15px;
       }
 
       &.card-stale {
-        border-left: 5px solid var(--danger-medium);
+        box-shadow: inset 5px 0px 0 0px var(--danger-medium);
+        border-left: 0px;
+        padding-left: 15px;
       }
 
       .card-row {


### PR DESCRIPTION
The old way of using borders makes ugly photo-frame
edges, this looks nicer

Before

![image](https://github.com/user-attachments/assets/b16a3124-12cc-463d-a695-53c0c4a4a084)

After

![image](https://github.com/user-attachments/assets/fbf89e45-e324-4c2f-a1b8-45bd2917c517)
