### PR TITLE
display kanban boards in fullscreen by default

### DIFF
--- a/javascripts/discourse/components/kanban/wrapper.gjs
+++ b/javascripts/discourse/components/kanban/wrapper.gjs
@@ -37,6 +37,11 @@ export default class Kanban extends Component {
 
   @tracked dragData;
 
+  constructor() {
+    super(...arguments);
+    this.kanbanManager.fullscreen = true; // Set fullscreen to true by default
+  }
+
   @action
   setDragData(data) {
     this.dragData = data;

--- a/spec/system/kanban_functionality_spec.rb
+++ b/spec/system/kanban_functionality_spec.rb
@@ -28,10 +28,11 @@ RSpec.describe "Testing A Theme or Theme Component", system: true do
     visit "/"
 
     expect(page).to have_css(".topic-list-item") # Fully loaded
-    expect(page).not_to have_css("body.kanban-active")
+    expect(page).to have_css("body.kanban-fullscreen")
 
     find(".kanban-nav").click
 
+    expect(page).not_to have_css("body.kanban-fullscreen")
     expect(page).to have_css("body.kanban-active")
     expect(page).to have_css(".discourse-kanban-list", count: 1)
     expect(page).to have_css(".discourse-kanban-list .topic-card", count: 4)


### PR DESCRIPTION
as the title says, this changes the behavious of the body class elements in the wrapper to display the board in fullscreen by default. 
Did those edit as we use the FKB Pro Element which does overlays elements over the kanban board unfortunately.