### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.4.0.beta2-dev: d1d4a64c7d3ad5542968fda184e249c2a5fd38be
 < 3.4.0.beta1-dev: b3c36ce64867a6a0486dee8232c73997e1f3ece0
 < 3.3.0.beta1-dev: c8b15afa2db6f9f0ccee83f4dd730ea4d67f6132
 < 3.1.0.beta2-dev: c78a3998cdafabde7b9fa2e99ddab8ad2449c994

--- a/javascripts/discourse/components/kanban/controls.gjs
+++ b/javascripts/discourse/components/kanban/controls.gjs
@@ -29,7 +29,7 @@ export default class KanbanControls extends Component {
     {{#if this.kanbanManager.active}}
       <DMenu
         class="kanban-controls"
-        @icon="far-list-alt"
+        @icon="far-rectangle-list"
         @title={{i18n (themePrefix "controls")}}
         as |menu|
       >

--- a/javascripts/discourse/components/kanban/wrapper.gjs
+++ b/javascripts/discourse/components/kanban/wrapper.gjs
@@ -67,7 +67,7 @@ export default class Kanban extends Component {
           <div class="fullscreen-close-wrapper">
             <DButton
               class="fullscreen-close"
-              @icon="times"
+              @icon="xmark"
               @action={{this.exitFullscreen}}
               @title={{themePrefix "fullscreen"}}
             />


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.