### PR TITLE
UX: Hide topic-list-layout-trigger button

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -5,6 +5,7 @@ html.kanban-active {
     margin-bottom: 0;
   }
 
+  .topic-list-layout-trigger,
   .powered-by-discourse {
     display: none;
   }


### PR DESCRIPTION
It doesn't affect the kanban view