### PR TITLE
DEV: Upgrade modifyClass syntax to remove object-literal decorators

### DIFF
--- a/javascripts/discourse/initializers/initialize-discourse-kanban.js
+++ b/javascripts/discourse/initializers/initialize-discourse-kanban.js
@@ -24,22 +24,25 @@ export default {
         refreshModel: true,
       });
 
-      api.modifyClass("component:navigation-item", {
-        pluginId: PLUGIN_ID,
+      api.modifyClass(
+        "component:navigation-item",
+        (Superclass) =>
+          class extends Superclass {
+            @service kanbanManager;
 
-        kanbanManager: service(),
-        @discourseComputed(
-          "content.filterMode",
-          "filterMode",
-          "kanbanManager.active"
-        )
-        active(contentFilterMode, filterMode, active) {
-          if (active) {
-            return false;
+            @discourseComputed(
+              "content.filterMode",
+              "filterMode",
+              "kanbanManager.active"
+            )
+            active(contentFilterMode, filterMode, active) {
+              if (active) {
+                return false;
+              }
+              return super.active;
+            }
           }
-          return this._super(contentFilterMode, filterMode);
-        },
-      });
+      );
 
       const routeToBoard = (transition, categorySlug) => {
         return (


### PR DESCRIPTION
Decorators on object literal properties are unsupported in most modern JS tooling, including ts/glint and Prettier 3.0. Using the new native-class-based modifyClass syntax means we can use decorators safely