### PR TITLE
DEV: fix flaky nav click in "filtered to tag" system spec

### DIFF
--- a/spec/system/kanban_functionality_spec.rb
+++ b/spec/system/kanban_functionality_spec.rb
@@ -80,6 +80,8 @@ RSpec.describe "Testing A Theme or Theme Component", system: true do
     tag_drop = PageObjects::Components::SelectKit.new(".category-breadcrumb .tag-drop")
     tag_drop.select_row_by_name("chat")
 
+    expect(page).to have_css(".topic-list-item", count: 2)
+
     find(".kanban-nav").click
 
     kanban_board.visit_tag_board(chat, descriptor: "tags:active,backlog")


### PR DESCRIPTION
Selecting a tag triggers a client-side transition that re-renders the `.kanban-nav` link, so clicking it immediately detaches the element mid-render ("element is not attached to the DOM"). Wait for the tag-filtered topic list before clicking, matching the sibling specs.